### PR TITLE
Add option

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,24 +23,6 @@ The "[Configuring SAML for Amazon Web Services (AWS) with Multiple Accounts and 
  - Add external roles to give OneLogin access to your AWS accounts
  - Complete your AWS Multi Account configuration in OneLogin
 
-## Installation
-
-### Hosting
-
-#### Github
-
-The project is hosted at github. You can download it from:
-* Latest release: https://github.com/onelogin/onelogin-python-aws-assume-role/releases/latest
-* Master repo: https://github.com/onelogin/onelogin-python-aws-assume-role/tree/master
-
-### Dependencies
-
-It works with Python 3.8+.
-
-* boto3  AWS Python SDK
-* onelogin  OneLogin Python SDK
-* pyyaml  YAML parser
-* lxml  XML and HTML processor
 
 ## Getting started
 
@@ -91,19 +73,8 @@ uv sync
 
 This will create a virtual environment in `.venv` and install all dependencies automatically.
 
-### Run the tool
 
-```bash
-# Run directly with uv
-uv run onelogin-aws-assume-role
-
-# Or activate the virtual environment first
-source .venv/bin/activate  # On Unix/macOS
-# .venv\Scripts\activate  # On Windows
-onelogin-aws-assume-role
-```
-
-### Settings
+## Settings
 
 The python script uses a settings file, where [OneLogin SDK properties](https://github.com/onelogin/onelogin-python-sdk#getting-started) are placed.
 
@@ -144,6 +115,7 @@ There is an optional file `onelogin.aws.json`, that can be used if you plan to e
   "aws_region": "us-west-2",
   "aws_account_id": "",
   "aws_role_name": "",
+  "mfa_device_type": "",
   "profiles": {
     "profile-1": {
       "aws_account_id": "",
@@ -168,6 +140,7 @@ Where:
  * aws_region AWS region to use
  * aws_account_id AWS account id to be used
  * aws_role_name AWS role name to select
+ * mfa_device_type MFA Device Type to use (to skip MFA device selection prompt, e.g., 'Google Authenticator', 'OneLogin Protect')
  * profiles Contains a list of profile->account id, and optionally role name mappings. If this attribute is populated `aws_account_id`, `aws_role_name`, `aws_region`, and `app_id` will be set based on the `profile` provided when running the script.
 
 **Note**: The values provided on the command line will take precedence over the values defined on this file and, values defined at the _global_ scope in the file, will take precedence over values defined at the `profiles` level. IN addition, each attribute is treating individually, so be aware that this may lead to somewhat strange behaviour when overriding a subset of parameters, when others are defined at a _lower level_ and not overridden. For example, if you had a `onelogin.aws.json` config file as follows:
@@ -197,16 +170,6 @@ accounts:
 
 This isn't needed for the script to function but it provides a better user experience.
 
-### Docker installation method
-
-* `git clone git@github.com:onelogin/onelogin-python-aws-assume-role.git`
-* `cd onelogin-python-aws-assume-role`
-* Enter your credentials in the `onelogin.sdk.json` file as explained above
-* Save the `onelogin.sdk.json` file in the root directory of the repo
-* `docker build . -t awsaccess:latest`
-* `docker run -it -v ~/.aws:/root/.aws -v $(pwd)/onelogin.sdk.json:/root/.onelogin/onelogin.sdk.json awsaccess:latest onelogin-aws-assume-role --onelogin-username {user_email} --onelogin-subdomain {subdomain} --onelogin-app-id {app_id} --aws-region {aws region} --profile default`
-
-Note: The Docker image is now based on uv for faster and more efficient dependency management.
 
 ### How the process works
 
@@ -228,6 +191,18 @@ You can specify
 OTP Code (`--otp`)
 and the cli will use this otp only for the first interaction
 requiring a manual OTP Code
+
+You can also specify
+MFA Device Type (`--mfa-device-type`)
+to skip the MFA device selection prompt. This is useful when you have multiple MFA devices registered
+and want to use a specific type without being prompted every time. Common device types include:
+- `Google Authenticator`
+- `OneLogin Protect`
+- `Yubico YubiKey`
+- `OneLogin SMS`
+
+You can find your MFA Device Type by running the tool once and noting the device type from the MFA device
+selection screen, or by configuring it in the `onelogin.aws.json` file with the `mfa_device_type` field.
 
 _Note: Specifying your password directly with `--onelogin-password` is bad practice,
 you should use that flag together with password managers, eg. with the OSX Keychain:
@@ -327,6 +302,17 @@ uv sync
 ```
 
 Development dependencies are automatically included with `uv sync`.
+
+### Docker installation method
+
+* `git clone git@github.com:onelogin/onelogin-python-aws-assume-role.git`
+* `cd onelogin-python-aws-assume-role`
+* Enter your credentials in the `onelogin.sdk.json` file as explained above
+* Save the `onelogin.sdk.json` file in the root directory of the repo
+* `docker build . -t awsaccess:latest`
+* `docker run -it -v ~/.aws:/root/.aws -v $(pwd)/onelogin.sdk.json:/root/.onelogin/onelogin.sdk.json awsaccess:latest onelogin-aws-assume-role --onelogin-username {user_email} --onelogin-subdomain {subdomain} --onelogin-app-id {app_id} --aws-region {aws region} --profile default`
+
+Note: The Docker image is now based on uv for faster and more efficient dependency management.
 
 ### Pre-commit hooks (Optional)
 

--- a/onelogin.aws.json.template
+++ b/onelogin.aws.json.template
@@ -7,6 +7,7 @@
   "aws_region": "",
   "aws_account_id": "",
   "aws_role_name": "",
+  "mfa_device_type": "",
   "profiles": {
     "profile-1": {
       "aws_account_id": "",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -99,18 +99,8 @@ select = [
 # Ignore specific rules for legacy code
 ignore = [
     "E501",    # line too long (handled by formatter)
-    "E711",    # comparison to None (legacy code)
     "E722",    # bare except (legacy code)
-    "N806",    # variable naming (legacy code)
-    "N812",    # lowercase imported as non-lowercase (legacy code)
-    "N999",    # invalid module name (aws-assume-role.py)
-    "UP031",   # use format specifiers (legacy code, can be fixed later)
-    "SIM102",  # nested if statements (legacy code)
-    "SIM105",  # contextlib.suppress (legacy code)
-    "SIM110",  # for loop to any (legacy code)
-    "SIM115",  # context manager for files (legacy code)
-    "SIM118",  # use 'in dict' instead of 'in dict.keys()' (legacy code)
-    "B006",    # mutable default argument (legacy code)
+
 ]
 
 # Allow fix for all enabled rules

--- a/src/aws_assume_role/accounts.py
+++ b/src/aws_assume_role/accounts.py
@@ -5,11 +5,12 @@
 # Currently the onelogin saml does not support pulling the acct alias dynamically with the role names
 
 import os
+from argparse import Namespace
 
 import yaml
 
 
-def get_account_aliases_info(config_file_path):
+def get_account_aliases_info(config_file_path) -> list:
     account_aliases = []
     accountsfile = None
 
@@ -25,7 +26,7 @@ def get_account_aliases_info(config_file_path):
     return account_aliases
 
 
-def identify_known_accounts(account_aliases, account_id):
+def identify_known_accounts(account_aliases, account_id) -> str:
     """
     Given a known list of account IDs from yaml config, append note about their account if they're known to us.
     :return: Account description
@@ -42,7 +43,7 @@ def identify_known_accounts(account_aliases, account_id):
         return ""
 
 
-def pretty_choices(index, role_name, account_id, account_aliases=[], mark=""):
+def pretty_choices(index: int, role_name: str, account_id: str, account_aliases: list, mark: str = ""):
     """
     Formats the output of the account option
     :return: formatted print
@@ -54,7 +55,9 @@ def pretty_choices(index, role_name, account_id, account_aliases=[], mark=""):
         print(" %s | %s (Account %s)%s" % (index, role_name, account_id, mark))
 
 
-def process_account_and_role_choices(info_indexed_by_account, info_indexed_by_roles, options):
+def process_account_and_role_choices(
+    info_indexed_by_account: dict, info_indexed_by_roles: dict, options: Namespace
+) -> tuple:
     role_option = None
     selection_info = []
     index = 0
@@ -83,7 +86,7 @@ def process_account_and_role_choices(info_indexed_by_account, info_indexed_by_ro
     return selection_info, role_option
 
 
-def check_info(account_id, role_name, config_account_id, config_role_name):
+def check_info(account_id, role_name, config_account_id, config_role_name) -> tuple:
     mark = ""
     found = False
     if account_id == config_account_id and role_name == config_role_name:

--- a/src/aws_assume_role/aws-assume-role.py
+++ b/src/aws_assume_role/aws-assume-role.py
@@ -1,1 +1,0 @@
-aws_assume_role.py

--- a/src/aws_assume_role/aws_assume_role.py
+++ b/src/aws_assume_role/aws_assume_role.py
@@ -277,7 +277,7 @@ def get_saml_response(
             )
             sys.exit()
 
-    if saml_endpoint_response and saml_endpoint_response.type == None:
+    if saml_endpoint_response and saml_endpoint_response.type is None:
         print("SAML assertion failed with message: ", saml_endpoint_response.message)
         sys.exit()
 

--- a/src/aws_assume_role/aws_assume_role.py
+++ b/src/aws_assume_role/aws_assume_role.py
@@ -14,7 +14,6 @@ import boto3
 import botocore.client
 from botocore.exceptions import ClientError
 from lxml import etree as ET
-
 from onelogin.api.client import OneLoginClient
 
 try:

--- a/src/aws_assume_role/aws_assume_role.py
+++ b/src/aws_assume_role/aws_assume_role.py
@@ -14,6 +14,7 @@ import boto3
 import botocore.client
 from botocore.exceptions import ClientError
 from lxml import etree as ET
+
 from onelogin.api.client import OneLoginClient
 
 try:
@@ -99,6 +100,11 @@ def get_options():
         default=1,
         help="The version of the OneLogin SAML APIs to use",
     )
+    parser.add_argument(
+        "--mfa-device-type",
+        dest="mfa_device_type",
+        help="MFA Device Type to use (to skip MFA device selection prompt, e.g., 'Google Authenticator', 'OneLogin Protect')",
+    )
 
     options = parser.parse_args()
 
@@ -122,6 +128,8 @@ def get_options():
             options.aws_account_id = config["aws_account_id"]
         if "aws_role_name" in config.keys() and config["aws_role_name"] and not options.aws_role_name:
             options.aws_role_name = config["aws_role_name"]
+        if "mfa_device_type" in config.keys() and config["mfa_device_type"] and not options.mfa_device_type:
+            options.mfa_device_type = config["mfa_device_type"]
         if (
             "profiles" in config.keys()
             and config["profiles"]
@@ -222,7 +230,15 @@ def check_device_exists(devices, device_id):
 
 
 def get_saml_response(
-    client, username_or_email, password, app_id, onelogin_subdomain, ip=None, mfa_verify_info=None, cmd_otp=None
+    client,
+    username_or_email,
+    password,
+    app_id,
+    onelogin_subdomain,
+    ip=None,
+    mfa_verify_info=None,
+    cmd_otp=None,
+    mfa_device_type=None,
 ):
     saml_endpoint_response = client.get_saml_assertion(username_or_email, password, app_id, onelogin_subdomain, ip)
 
@@ -287,17 +303,40 @@ def get_saml_response(
             # Consider case 0 or MFA that requires a trigger
             if mfa_verify_info is None or device_type in ["OneLogin SMS", "OneLogin Protect"]:
                 if mfa_verify_info is None:
-                    print("-----------------------------------------------------------------------")
-                    for index, device in enumerate(devices):
-                        print(" " + str(index) + " | " + device.type)
+                    # If mfa_device_type is specified, try to find matching device
+                    if mfa_device_type:
+                        device_selection = None
+                        for index, device in enumerate(devices):
+                            if device.type == mfa_device_type:
+                                device_selection = index
+                                print("Using MFA device: %s (type: %s)" % (device.id, device.type))
+                                break
 
-                    print("-----------------------------------------------------------------------")
-
-                    if len(devices) > 1:
-                        print("\nSelect the desired MFA Device [0-%s]: " % (len(devices) - 1))
-                        device_selection = get_selection(len(devices))
+                        if device_selection is None:
+                            print("Specified MFA device type '%s' not found." % mfa_device_type)
+                            print("Available devices:")
+                            print("-----------------------------------------------------------------------")
+                            for index, device in enumerate(devices):
+                                print(" " + str(index) + " | " + device.type)
+                            print("-----------------------------------------------------------------------")
+                            if len(devices) > 1:
+                                print("\nSelect the desired MFA Device [0-%s]: " % (len(devices) - 1))
+                                device_selection = get_selection(len(devices))
+                            else:
+                                device_selection = 0
                     else:
-                        device_selection = 0
+                        print("-----------------------------------------------------------------------")
+                        for index, device in enumerate(devices):
+                            print(" " + str(index) + " | " + device.type)
+
+                        print("-----------------------------------------------------------------------")
+
+                        if len(devices) > 1:
+                            print("\nSelect the desired MFA Device [0-%s]: " % (len(devices) - 1))
+                            device_selection = get_selection(len(devices))
+                        else:
+                            device_selection = 0
+
                     device = devices[device_selection]
                     device_id = device.id
                     device_type = device.type
@@ -364,7 +403,15 @@ def get_saml_response(
                         # State token expired so the OTP Token was not able to be processed
                         # regenerate new SAMLResponse and get new state_token
                         return get_saml_response(
-                            client, username_or_email, password, app_id, onelogin_subdomain, ip, mfa_verify_info
+                            client,
+                            username_or_email,
+                            password,
+                            app_id,
+                            onelogin_subdomain,
+                            ip,
+                            mfa_verify_info,
+                            None,
+                            mfa_device_type,
                         )
                     else:
                         if mfa_error > MFA_ATTEMPTS_FOR_WARNING and len(devices) > 1:
@@ -377,7 +424,15 @@ def get_saml_response(
                                 # Let's regenerate the SAMLResponse and initialize again the count
                                 print("\n")
                                 return get_saml_response(
-                                    client, username_or_email, password, app_id, onelogin_subdomain, ip, None
+                                    client,
+                                    username_or_email,
+                                    password,
+                                    app_id,
+                                    onelogin_subdomain,
+                                    ip,
+                                    None,
+                                    None,
+                                    mfa_device_type,
                                 )
                             else:
                                 print("Ok, Try introduce a new OTP Token then: ")
@@ -676,8 +731,19 @@ def main():
                 onelogin_subdomain = sys.stdin.readline().strip()
 
         if result is None:
+            mfa_device_type_to_use = None
+            if hasattr(options, "mfa_device_type") and options.mfa_device_type:
+                mfa_device_type_to_use = options.mfa_device_type
             result = get_saml_response(
-                client, username_or_email, password, app_id, onelogin_subdomain, ip, mfa_verify_info, cmd_otp
+                client,
+                username_or_email,
+                password,
+                app_id,
+                onelogin_subdomain,
+                ip,
+                mfa_verify_info,
+                cmd_otp,
+                mfa_device_type_to_use,
             )
 
             username_or_email = result["username_or_email"]


### PR DESCRIPTION
This pull request introduces support for specifying the MFA device type in both the CLI and configuration file, allowing users to skip the MFA device selection prompt and streamline authentication. It also improves type annotations in `accounts.py`, updates documentation to reflect the new feature, and refactors some code for clarity and maintainability.

### MFA Device Type Support

* Added `--mfa-device-type` CLI argument and `mfa_device_type` field in `onelogin.aws.json` and its template, enabling users to specify their preferred MFA device type and bypass the selection prompt. [[1]](diffhunk://#diff-ff3e83bc668dc2e056879e34f32047c8ee45e5921f00bf24331bb0236e3e7564R103-R107) [[2]](diffhunk://#diff-ff3e83bc668dc2e056879e34f32047c8ee45e5921f00bf24331bb0236e3e7564R131-R132) [[3]](diffhunk://#diff-c49871e0b1337cd5224341ea71aa71d812b0a3489737dd2e570f35dd1378ef0aR10) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R118) [[5]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R143)
* Updated the MFA device selection logic in `get_saml_response` to use the specified device type if provided, including error handling and fallback to manual selection if the type is not found. [[1]](diffhunk://#diff-ff3e83bc668dc2e056879e34f32047c8ee45e5921f00bf24331bb0236e3e7564R306-R327) [[2]](diffhunk://#diff-ff3e83bc668dc2e056879e34f32047c8ee45e5921f00bf24331bb0236e3e7564R339) [[3]](diffhunk://#diff-ff3e83bc668dc2e056879e34f32047c8ee45e5921f00bf24331bb0236e3e7564L367-R414) [[4]](diffhunk://#diff-ff3e83bc668dc2e056879e34f32047c8ee45e5921f00bf24331bb0236e3e7564L380-R435) [[5]](diffhunk://#diff-ff3e83bc668dc2e056879e34f32047c8ee45e5921f00bf24331bb0236e3e7564R734-R746)

### Documentation Updates

* Revised `README.md` to document the new MFA device type feature, including usage instructions and configuration examples. Also reorganized installation and settings sections for clarity. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L94-R77) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L200-L209) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R195-R206) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R306-R316)

### Code Quality Improvements

* Added type annotations to functions in `accounts.py` for better readability and maintainability. [[1]](diffhunk://#diff-0c826831d11a0226363a767b9bf2b02a4fe513bf31eb25fb3680a92494048d9dR8-R13) [[2]](diffhunk://#diff-0c826831d11a0226363a767b9bf2b02a4fe513bf31eb25fb3680a92494048d9dL28-R29) [[3]](diffhunk://#diff-0c826831d11a0226363a767b9bf2b02a4fe513bf31eb25fb3680a92494048d9dL45-R46) [[4]](diffhunk://#diff-0c826831d11a0226363a767b9bf2b02a4fe513bf31eb25fb3680a92494048d9dL57-R60) [[5]](diffhunk://#diff-0c826831d11a0226363a767b9bf2b02a4fe513bf31eb25fb3680a92494048d9dL86-R89)
* Minor code style and import cleanups in `aws_assume_role.py`. [[1]](diffhunk://#diff-ff3e83bc668dc2e056879e34f32047c8ee45e5921f00bf24331bb0236e3e7564R17) [[2]](diffhunk://#diff-ff3e83bc668dc2e056879e34f32047c8ee45e5921f00bf24331bb0236e3e7564L264-R280)

### Miscellaneous

* Removed obsolete `aws_assume_role.py` file.
* Updated `pyproject.toml` to clean up ignored linting rules.